### PR TITLE
change attribute lookup from has_key to in

### DIFF
--- a/custom_components/ledfxrm/light.py
+++ b/custom_components/ledfxrm/light.py
@@ -182,7 +182,7 @@ class LedfxrmChildLight(LedfxrmLight):
     @property
     def icon(self):
         """Return the icon of this light."""
-        if self.deviceconfig.has_key("icon_name")
+        if self.deviceconfig.has_key("icon_name"):
             if self.deviceconfig["icon_name"].startswith("mdi:"):
                 return self.deviceconfig["icon_name"]
             else:

--- a/custom_components/ledfxrm/light.py
+++ b/custom_components/ledfxrm/light.py
@@ -182,7 +182,7 @@ class LedfxrmChildLight(LedfxrmLight):
     @property
     def icon(self):
         """Return the icon of this light."""
-        if self.deviceconfig.has_key("icon_name"):
+        if "icon_name" in self.deviceconfig:
             if self.deviceconfig["icon_name"].startswith("mdi:"):
                 return self.deviceconfig["icon_name"]
             else:


### PR DESCRIPTION
fixes #6 

I received this error 
```
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 316, in async_add_entities
    await asyncio.gather(*tasks)
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 427, in _async_add_entity
    original_icon=entity.icon,
  File "/config/custom_components/ledfxrm/light.py", line 185, in icon
    if self.deviceconfig.has_key("icon_name"):
AttributeError: 'dict' object has no attribute 'has_key'
```
It seems `has_key` was removed in python 3: https://stackoverflow.com/a/33727186 

So use the `in` operator instead seemed to work in my testing, although I do not have a custom icon (I think) so was unable to test inside the if statement. 